### PR TITLE
Allow src folder in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,6 @@
 		"gruntfile.js",
 		"package.js",
 		"package.json",
-		"src",
 		"test"
 	],
 	"dependencies": {


### PR DESCRIPTION
There is no way to get to scss files using bower (milligram or milligram-scss). So it should be ideally available at least in one of them.