### PR TITLE
add -webkit-appearance: none to Button

### DIFF
--- a/src/_Button.sass
+++ b/src/_Button.sass
@@ -23,6 +23,7 @@ input[type='submit']
 	text-decoration: none
 	text-transform: uppercase
 	white-space: nowrap
+	-webkit-appearance: none
 
 	&:hover,
 	&:focus


### PR DESCRIPTION
Webkit shows rounded submit buttons. Screenshot is taken of the bottom of http://papercast.xyz/ on iPhone 6+
![file 2016-01-28 00 10 07](https://cloud.githubusercontent.com/assets/102791/12635679/faa6a04a-c553-11e5-9478-6e7fb5e7c0a0.png)