### PR TITLE
Remove `src` from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,5 +9,4 @@ contributing.md
 gruntfile.js
 package.js
 package.json
-src
 test


### PR DESCRIPTION
Remove `src` from npmignore so I can install milligram
via npm, and include it from my main SASS/SCSS file.