### PR TITLE
grid: fix row & col vertical alignment class scope

### DIFF
--- a/src/_Grid.sass
+++ b/src/_Grid.sass
@@ -36,19 +36,19 @@
 
 	// Vertically Align Columns
 	// .row-* vertically aligns every .col in the .row
-	.row-top
+	&.row-top
 		align-items: flex-start
 
-	.row-bottom
+	&.row-bottom
 		align-items: flex-end
 
-	.row-center
+	&.row-center
 		align-items: center
 
-	.row-stretch
+	&.row-stretch
 		align-items: stretch
 
-	.row-baseline
+	&.row-baseline
 		align-items: baseline
 
 	.column
@@ -59,13 +59,13 @@
 		width: 100%
 
 		// .column-* vertically aligns an individual .column
-		.col-top
+		&.col-top
 			align-self: flex-start
 
-		.col-bottom
+		&.col-bottom
 			align-self: flex-end
 
-		.col-center
+		&.col-center
 			align-self: center
 
 		// Column Offsets


### PR DESCRIPTION
Before the change sass output for the vertical aligment rules was `.row .row-center {}`. With the change it will be `.row.row-center {}`.