### PR TITLE
Fixed issue with IE11 and flex:1

### DIFF
--- a/src/_Grid.sass
+++ b/src/_Grid.sass
@@ -53,7 +53,8 @@
 
 	.column
 		display: block
-		flex: 1
+		// IE 11 required specifying the flex-basis otherwise it breaks mobile
+		flex: 1 1 auto
 		margin-left: 0
 		max-width: 100%
 		width: 100%


### PR DESCRIPTION
Fixes #84

According to https://github.com/philipwalton/flexbugs IE11 default shorthand `flex` css value do not work correctly. Changing this to specify the individual `flex-grow`, `flex-shrink`, and `flex-basis` values fixes this issue.
