### PR TITLE
Allow sass usage from npm package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,5 +10,4 @@ component.json
 composer.json
 package.js
 package.json
-src
 test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 	"license": "MIT",
 	"author": "CJ Patoilo <cjpatoilo@gmail.com>",
 	"main": "dist/milligram.css",
+	"files": [
+		"src"
+	],
 	"keywords": [
 		"bootstrap",
 		"css",


### PR DESCRIPTION
Hi, 

I want to use the sass version of milligram when installing it with npm. This requires the src directory to be included though. This will add the src directory to the published npm package.