### PR TITLE
Removed engines from package.json to avoid dependency problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
 		"postcss-cli": "^2.6.0",
 		"sass-lint": "^1.10.2"
 	},
-	"engines": {
-		"node": "^7.0.0"
-	},
 	"scripts": {
 		"prestart": "npm install",
 		"pretest": "npm install",


### PR DESCRIPTION
<!--

We would love for you to contribute to Milligram and help us make this even better! Start reading this [document](https://github.com/milligram/milligram/blob/master/.github/contributing.md) to see it is not difficult as you might have imagined.

Submit a Pull Request
==============================
To submit a new feature, make sure that changes are done to the source code. [Follow our style guide](https://github.com/milligram/milligram/blob/master/.github/contributing.md#style-guide) and do not forget the tests and attach the link [Codepen](http://codepen.io/) along with the description.

Try to solve a problem for each pull request, this increases the chances of acceptance. When in doubt, open a [new issue](https://github.com/milligram/milligram/blob/master/.github/contributing.md#open-an-issue) so we can answer you. Look existing issues for ideas or to see if a similar issue has already been submitted.

1. Fork the Github repo: `git clone https://github.com/milligram/milligram.git`
1. Create a new branch: `git checkout -b issuenumber-feature-name`
1. Commit your changes: `git commit -m 'issuenumber-feature-name'`
1. Push to the branch: `git push origin my-feature-name`
1. Submit a pull request!

*Note: For issues relating to the site, please use the [milligram.github.io](https://github.com/milligram/milligram.github.io)*

Code of Conduct
==============================
Help us keep Milligram open and inclusive. Please read and follow our thoughts on [Code of Conduct](http://confcodeofconduct.com/).

License
==============================
By contributing your code, you agree to license your contribution under the [MIT license](https://github.com/milligram/milligram#license).

-->


### Description

It seems there's not a lot of benefit for an essentially client-side dependency to specify a node version. It's not possible to consume the library as an npm dependency (for use with Browserify or Webpack) and use a node version lower than 7, but there's not a good reason for that to be prevented.

### Code sample

```
$ yarn add milligram
yarn add v0.15.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error milligram@1.2.2: The engine "node" is incompatible with this module. Expected version "^7.0.0".
error Found incompatible module
info Visit http://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

