### PR TITLE
Improvements on select arrow

### DIFF
--- a/src/_Form.sass
+++ b/src/_Form.sass
@@ -33,11 +33,11 @@ select
 		outline: 0
 
 select
-	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%23' + str-slice(inspect($color-quaternary), 2) + '" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>') center right no-repeat
+	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%23' + str-slice(inspect($color-quaternary), 2) + '" d="M0,0l6,8l6-8"/></svg>') center right no-repeat
 	padding-right: 3.0rem
 
 	&:focus
-		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%23' + str-slice(inspect($color-primary), 2) + '" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')
+		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 8" width="30"><path fill="%23' + str-slice(inspect($color-primary), 2) + '" d="M0,0l6,8l6-8"/></svg>')
 
 textarea
 	min-height: 6.5rem

--- a/src/_Form.sass
+++ b/src/_Form.sass
@@ -33,11 +33,11 @@ select
 		outline: 0
 
 select
-	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%23d1d1d1" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>') center right no-repeat
+	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%23' + str-slice(inspect($color-quaternary), 2) + '" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>') center right no-repeat
 	padding-right: 3.0rem
 
 	&:focus
-		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%239b4dca" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')
+		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%23' + str-slice(inspect($color-primary), 2) + '" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')
 
 textarea
 	min-height: 6.5rem


### PR DESCRIPTION
### Description

Changed select arrow static colors to variables to meet the user theme colors.
The colors were fixed with the standard values from milligram, now it's using `$color-primary` and `$color-quaternary`.

![image](https://user-images.githubusercontent.com/1838187/46910751-0399c380-cf42-11e8-9aed-220f26c12cc4.png)

---

Also, I've improved svg drawing with a better canvas and integer values for points, which saves a lot of chars (92 bytes).

![image](https://user-images.githubusercontent.com/1838187/46910722-53c45600-cf41-11e8-8d44-a718f057dab9.png)

