### PR TITLE
Fix default font-family for form inputs: Avoid using Helvetica

### DIFF
--- a/src/_Base.sass
+++ b/src/_Base.sass
@@ -22,3 +22,8 @@ body
 	font-weight: 300
 	letter-spacing: .01em
 	line-height: 1.6
+
+// normalize.css sets font-family to sans-serif. The default sans-serif font
+// for Mac is Helvetica, but it has a strange baseline so the text is not vertically centered.
+button, input, optgroup, select, textarea
+	font-family: 'Roboto', 'Helvetica Neue', 'Arial', sans-serif

--- a/src/_Form.sass
+++ b/src/_Form.sass
@@ -25,7 +25,7 @@ select
 	box-shadow: none
 	box-sizing: inherit // Forced to replace inherit values of the normalize.css
 	height: 3.8rem
-	padding: .6rem 1.0rem // The .6rem vertically centers text on FF, ignored by Webkit
+	padding: .6rem 1.0rem .5rem // This vertically centers text on FF, ignored by Webkit
 	width: 100%
 
 	&:focus


### PR DESCRIPTION
Fixes #218

### Description

`normalize.css` has the following CSS rule:

```css
button, input, optgroup, select, textarea {
  font-family: sans-serif;
}
```

(This overrides the `body` `font-family` from milligram.) The default `sans-serif` font for Mac is `Helvetica`, but it has a strange baseline so the text is not vertically centered.

My solution is to override this rule from `normalize.css`, and default to using fonts that have a correct baseline. This means that the input text will be vertically centered by default:

```css
button, input, optgroup, select, textarea {
  font-family: 'Roboto', 'Helvetica Neue', 'Arial', sans-serif;
}
```

Here's what the forms look like after this change. You can see the original at the bottom of the fallbacks, under `sans-serif`.

### `Roboto`:

<img width="831" alt="screen shot 2018-11-10 at 3 43 53 pm" src="https://user-images.githubusercontent.com/139536/48299495-159a6200-e500-11e8-8fd0-3e99474b3aa5.png">

### Fallback to `Helvetica Neue`:

<img width="795" alt="screen shot 2018-11-10 at 3 54 12 pm" src="https://user-images.githubusercontent.com/139536/48299550-e3d5cb00-e500-11e8-975b-ce68a719dc3b.png">

### Fallback to `Arial`:

<img width="804" alt="screen shot 2018-11-10 at 3 54 51 pm" src="https://user-images.githubusercontent.com/139536/48299563-ff40d600-e500-11e8-9b20-797ccbd36a07.png">

### Fallback to `sans-serif` (`Helvetica` on Mac)

<img width="797" alt="screen shot 2018-11-10 at 3 44 09 pm" src="https://user-images.githubusercontent.com/139536/48299494-159a6200-e500-11e8-9a2f-f6e4408a07d6.png">



