### PR TITLE
Add column-offset-40

### DIFF
--- a/src/_Grid.sass
+++ b/src/_Grid.sass
@@ -75,6 +75,9 @@
 		&.column-offset-50
 			margin-left: 50%
 
+		&.column-offset-60
+			margin-left: 60%
+
 		&.column-offset-66,
 		&.column-offset-67
 			margin-left: 66.6666%

--- a/src/_Grid.sass
+++ b/src/_Grid.sass
@@ -69,6 +69,9 @@
 		&.column-offset-34
 			margin-left: 33.3333%
 
+		&.column-offset-40
+			margin-left: 40%
+
 		&.column-offset-50
 			margin-left: 50%
 


### PR DESCRIPTION
Right now, there is a `column-40` property but no `column-offset-40`:

https://github.com/milligram/milligram/blob/4aa4f64a3696042c37f0bab10b1ab13dbfd23cd7/src/_Grid.sass#L109-L111