### PR TITLE
252 remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,6 @@
     "visual-regression:reference": "run-s build && backstop reference --config backstop.config.js",
     "watch": "onchange src -- run-p build"
   },
-  "engines": {
-    "node": "^12.17.0",
-    "npm": "^6.14.5"
-  },
   "prettier": {
     "jsxSingleQuote": false,
     "trailingComma": "all"


### PR DESCRIPTION
This Pull Request should close the issue #252 

### Description

Consumers of the npm package just get the dist files so they aren't affected by this AFAICT. What Milligram uses to build and develop itself does shouldn't affect consumers. So having a Node.js version could be considered wrong.

This will allow Milligram to use whatever Node.js version we want to use without having to support unsupported Node.js versions anymore. 

Maybe in the future make sense Milligram to use only the up to date versions of the Node.js (>=lts) but for now, the `engines` property should be removed from package.json

### Hightlight

- remove the `engines` property from package.json (8c80c8f)