### PR TITLE
iOS: remove the color of the highlight that appears over a link while it's being tapped

### DIFF
--- a/src/_Link.sass
+++ b/src/_Link.sass
@@ -5,6 +5,8 @@
 a
   color: $color-primary
   text-decoration: none
+  /* iOS: remove the color of the highlight that appears over a link while it's being tapped */
+  -webkit-tap-highlight-color: transparent
 
   &:focus,
   &:hover


### PR DESCRIPTION
<!--

We would love for you to contribute to Milligram and help us make this even better! Start reading this [document](contributing.md) to see it is not difficult as you might have imagined.

Submit a Pull Request
==============================
To submit a new feature, make sure that changes are done to the source code. [Follow our style guide](contributing.md#style-guide) and do not forget the tests and attach the link [Codepen](http://codepen.io/) along with the description.

Try to solve a problem for each pull request, this increases the chances of acceptance. When in doubt, open a [new issue](contributing.md#open-an-issue) so we can answer you. Look existing issues for ideas or to see if a similar issue has already been submitted.

1. Fork the Github repo: `git clone https://github.com/milligram/milligram.git`
1. Create a new branch: `git checkout -b issuenumber-feature-name`
1. Commit your changes: `git commit -m 'issuenumber-feature-name'`
1. Push to the branch: `git push origin my-feature-name`
1. Submit a pull request!

_Note: For issues relating to the site, please use the [milligram/milligram.github.io](https://github.com/milligram/milligram.github.io)_

Code of Conduct
==============================
Help us keep Milligram open and inclusive. Please read and follow our thoughts on [Code of Conduct](http://confcodeofconduct.com/).

License
==============================
By contributing your code, you agree to license your contribution under the [MIT license](../license).

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Updating the documentation? Describe here something about your changes. Don't forget to add the link to the open issue, or to other pull request related. -->

New feature: iOS: remove the color of the highlight that appears over a link while it's being tapped
