### PR TITLE
Changed depedenices status url in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![Travis Status](https://travis-ci.org/milligram/milligram.svg?branch=master)](https://travis-ci.org/milligram/milligram?branch=master)
 [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/xcm8meymwerq0r82?svg=true)](https://ci.appveyor.com/project/cjpatoilo/milligram)
 [![Codacy Status](https://img.shields.io/codacy/grade/848fb4bd6902434fab0bcfb5461284fe/master.svg)](https://www.codacy.com/app/milligram/milligram/dashboard)
-[![Dependencies Status](https://david-dm.org/milligram/milligram.svg)](https://david-dm.org/milligram/milligram)
+[![Dependencies Status](https://img.shields.io/librariesio/github/milligram/milligram)](https://david-dm.org/milligram/milligram)
 [![Version Status](https://badge.fury.io/js/milligram.svg)](https://www.npmjs.com/package/milligram)
 [![Download Status](https://img.shields.io/npm/dt/milligram.svg)](https://www.npmjs.com/package/milligram)
 [![Gitter Chat](https://img.shields.io/badge/gitter-join_the_chat-4cc61e.svg)](https://gitter.im/milligram/milligram)


### PR DESCRIPTION
Changed depedenices status badge url in readme.md due to David-dm.org unavailibility.

issue #350
from :
![image](https://github.com/milligram/milligram/assets/82649533/8223b9d1-4ab3-48bb-ba78-b567a9acb125)

To:
![image](https://github.com/milligram/milligram/assets/82649533/c41a01bc-fec3-40d1-8fe3-9d1a65747ca2)
