### PR TITLE
Update appveyor to fix builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,14 @@
-os: Visual Studio 2015
+os: Visual Studio 2022
 version: '{build}'
 build: off
 platform: x64
 environment:
   matrix:
-    - nodejs_version: 12
+    - nodejs_version: 18
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - set CI=true
-  - npm i -g npm@latest
+  - npm i -g npm@"10-11"
   - set PATH=%APPDATA%\npm;%PATH%
   - npm i
 matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - set CI=true
-  - npm i -g npm@"10-11"
+  - npm i -g npm@">=10.2.0 <11.0.0"
   - set PATH=%APPDATA%\npm;%PATH%
   - npm i
 matrix:


### PR DESCRIPTION
### Description

Fixing the build pipeline for appveyor
 - nodejs v12 can't be used with npm@latest

bumped versions to latest, but fixed in place

### Bug sample

![image](https://github.com/milligram/milligram/assets/2555461/0166ee97-9c5f-4421-8270-1bf491ba28a8)

