### PR TITLE
docs: add Bun as a package manager option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,12 @@ $ npm install milligram
 $ yarn add milligram
 ```
 
+**Install with Bun**
+
+```sh
+$ bun add milligram
+```
+
 ## Table of Contents
 
 - [Getting Started](https://milligram.io/#getting-started)


### PR DESCRIPTION
Added [Bun](https://bun.sh/) as a package manager option in the README's Download section, alongside the existing Bower, npm, and Yarn options.
Bun is a modern, high-performance JavaScript runtime and package manager that is growing rapidly in adoption. Since milligram is published on npm, it works seamlessly with `bun add milligram`.
## Changes
- Added an "Install with Bun" section to `readme.md` after the Yarn section, following the same formatting pattern as the existing options.
This is a documentation-only change with no code impact.